### PR TITLE
docs: fix config file name in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,10 +32,10 @@ confluence_api_token = <your api token>
 confluence_email = <confluence user email>
 ```
 
-3. create `profile`
+3. create `config` file
 
 ```bash
-vim ~/.gpc/profile
+vim ~/.gpc/config
 
 [<profile name>]
 space_key = confluence space key to generate page  


### PR DESCRIPTION
Thank you for making the best tool ever!

I have fixed the configuration file path in the README from `~/.gpc/profile` to `~/.gpc/config` to match the actual behavior.